### PR TITLE
fix(utils_grid): use embedding-dim axis for NaN imputation in _create_spot (#9)

### DIFF
--- a/src/aestetik/utils/utils_grid.py
+++ b/src/aestetik/utils/utils_grid.py
@@ -177,7 +177,12 @@ def _create_spot(spot_idx: int,
     
     median_spot = np.nanmedian(grid, axis=(0, 1))
     nan_indices = np.where(np.isnan(grid))
-    grid[nan_indices] = np.take(median_spot, nan_indices[1])
+    # `grid` has shape (W, W, D); `nan_indices` is a 3-tuple of
+    # (row, col, embedding_dim) coords. `median_spot` has shape (D,) so
+    # the per-NaN-cell fill must come from the **embedding-dim** axis,
+    # not the column axis. The previous `nan_indices[1]` could
+    # IndexError when W > D and silently corrupted values when W <= D.
+    grid[nan_indices] = np.take(median_spot, nan_indices[2])
 
     return grid
 


### PR DESCRIPTION
Fixes #9. `_create_spot` builds a grid of shape `(window_size, window_size, embedding_dim)` (W, W, D) and fills empty neighbor cells with the per-dimension median:

```python
median_spot = np.nanmedian(grid, axis=(0, 1))   # shape (D,)
nan_indices = np.where(np.isnan(grid))           # 3-tuple: (rows, cols, dims)
grid[nan_indices] = np.take(median_spot, nan_indices[1])
```

`np.take` was being indexed by **column** position (`nan_indices[1]`, range 0..W-1), but `median_spot` is indexed by **embedding-dim** (range 0..D-1). Two failure modes:

1. `W > D` (e.g. window_size=9, PCA dim=5), `np.take` raises IndexError mid-grid.
2. `W <= D` (the default window_size=7 with PCA dim=15), silent corruption: each NaN cell gets filled with whatever median happens to live at the column index, not its own embedding dimension.

## Change

`src/aestetik/utils/utils_grid.py:180`, `nan_indices[1]` → `nan_indices[2]`.

## Test plan

- [x] Manual repro: synthetic `(7, 7, 15)` grid with two non-NaN cells; old vs new `np.take` results differ for every NaN cell, confirming the silent-corruption mode
- [x] AST parse on the modified file is clean