### PR TITLE
build(deps): cap numpy<2 on py3.9 to fix squidpy import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,10 @@ dependencies = [
     "torch>=2.0",
     "torchvision>=0.15",
     "lightning>=2.0",
-    "numpy>=1.23",
+    # spatialdata still references np.float_ on its py3.9-compatible
+    # release line; numpy 2.0 removed it. Cap numpy<2 on py3.9.
+    "numpy>=1.23; python_version>='3.10'",
+    "numpy>=1.23,<2; python_version<'3.10'",
     "pandas>=1.5",
     "scipy>=1.10",
     "anndata>=0.9",


### PR DESCRIPTION
Newer numpy 2.0 removed np.float_, which is still referenced by the spatialdata release line resolved on Python 3.9. Pin numpy<2 via an environment marker so the squidpy import chain succeeds in CI.